### PR TITLE
Uses the emitter as the context when a callback is called.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ emitter.off(ref);
 
 ### `emitter.trigger(name, ...args)`
 
-Trigger all handlers for the given name with the remaining arguments `args`.
+Trigger all handlers for the given name with the remaining arguments `args`. The
+callbacks are called with the emitter as `this`.
 
 ```javascript
 function testCallback(a, b, c) {

--- a/test/index.js
+++ b/test/index.js
@@ -120,6 +120,10 @@ describe('EventEmitter', () => {
         assert.deepEqual(callback2.args, [[1, 2, 3]]);
       });
 
+      it('calls callbacks with the emitter as context', () => {
+        assert.equal(callback1.firstCall.thisValue, emitter);
+      });
+
       it('does not call callbacks for other events', () => {
         assert.equal(callback3.callCount, 0);
       });

--- a/vertebrate-event-emitter.js
+++ b/vertebrate-event-emitter.js
@@ -5,7 +5,7 @@ const allHandlersPrivateData = new WeakMap();
 function useCallback(eventReference, args) {
   const privateData = allHandlersPrivateData.get(eventReference);
 
-  privateData.callback.apply(null, args);
+  privateData.callback.apply(this, args);
   privateData.count--;
 
   return privateData.count === 0;
@@ -83,7 +83,7 @@ export class EventEmitter {
     const args = Array.prototype.slice.call(arguments, 1);
 
     for (const eventReference of allEventsForThisEventName) {
-      const done = useCallback(eventReference, args);
+      const done = useCallback.call(this, eventReference, args);
 
       if (done) {
         allEventsForThisEventName.delete(eventReference);


### PR DESCRIPTION
Closes #3.
