### PR TITLE
Adds emit alias for trigger and allOff method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ const ref = emitter.on('event-name', callback);
 emitter.off(ref);
 ```
 
+### `emitter.allOff(name = undefined)`
+
+When called with a name string, all events for that name are removed from the
+emitter. When called without a name string, all events for all names are
+removed.
+
 ### `emitter.trigger(name, ...args)`
 
 Trigger all handlers for the given name with the remaining arguments `args`. The
@@ -86,6 +92,10 @@ emitter.on('some-event', testCallback);
 
 emitter.trigger('some-event', 1, 2, 3) // logs: 1, 2, 3
 ```
+
+### `emitter.emit(name, ...args)`
+
+Alias for `emitter.trigger`.
 
 ## Problems with existing emitters
 

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,10 @@ describe('EventEmitter', () => {
       assert.equal(typeof emitter.trigger, 'function');
     });
 
+    it('has an "emit" method as an alias for the "trigger" method', () => {
+      assert.equal(emitter.emit, emitter.trigger);
+    });
+
     describe('the "on" method', () => {
       it('throws when given a non-string event name', () => {
         assert.throws(
@@ -174,6 +178,76 @@ describe('EventEmitter', () => {
         emitter.trigger('test-event', 'abc');
 
         assert.deepEqual(callback.args, [['abc']]);
+      });
+    });
+
+    describe('the "allOff" method', () => {
+      let callback1;
+      let callback2;
+      let callback3;
+
+      let handler1;
+
+      let anotherEmitter;
+
+      beforeEach(() => {
+        callback1 = sinon.stub();
+        callback2 = sinon.stub();
+        callback3 = sinon.stub();
+
+        handler1 = emitter.on('test-event', callback1);
+        emitter.on('another-event', callback2);
+
+        anotherEmitter = new EventEmitter();
+        anotherEmitter.on('test-event', callback3);
+      });
+
+      describe('when called without a name', () => {
+        beforeEach(() => {
+          emitter.allOff();
+        });
+
+        it('removes all listeners for the emitter', () => {
+          emitter.trigger('test-event');
+          emitter.trigger('another-event');
+
+          assert.equal(callback1.callCount, 0);
+          assert.equal(callback2.callCount, 0);
+        });
+
+        it('does not throw an error when removing an already removed handler', () => {
+          emitter.off(handler1);
+        });
+
+        it('does not affect other emitters', () => {
+          anotherEmitter.trigger('test-event');
+
+          assert.equal(callback3.callCount, 1);
+        });
+      });
+
+      describe('when called with a name', () => {
+        beforeEach(() => {
+          emitter.allOff('test-event');
+        });
+
+        it('removes listeners for the given name on the emitter', () => {
+          emitter.trigger('test-event');
+          emitter.trigger('another-event');
+
+          assert.equal(callback1.callCount, 0);
+          assert.equal(callback2.callCount, 1);
+        });
+
+        it('does not throw an error when removing an already removed handler', () => {
+          emitter.off(handler1);
+        });
+
+        it('does not affect other emitters', () => {
+          anotherEmitter.trigger('test-event');
+
+          assert.equal(callback3.callCount, 1);
+        });
       });
     });
   });

--- a/vertebrate-event-emitter.js
+++ b/vertebrate-event-emitter.js
@@ -77,7 +77,9 @@ EventEmitter.prototype.off = function (handler) {
   var allEventsForThisEmitter = allEventsForAllEmitters.get(this);
   var allEventsForThisEventName = allEventsForThisEmitter.get(eventName);
 
-  allEventsForThisEventName.delete(handler);
+  if (allEventsForThisEventName) {
+    allEventsForThisEventName.delete(handler);
+  }
 };
 
 EventEmitter.prototype.trigger = function (eventName) {
@@ -93,4 +95,16 @@ EventEmitter.prototype.trigger = function (eventName) {
       allEventsForThisEventName.delete(eventReference);
     }
   });
+};
+
+EventEmitter.prototype.emit = EventEmitter.prototype.trigger;
+
+EventEmitter.prototype.allOff = function (eventName) {
+  var allEventsForThisEmitter = allEventsForAllEmitters.get(this);
+
+  if (typeof eventName === 'string') {
+    allEventsForThisEmitter.delete(eventName);
+  } else {
+    allEventsForThisEmitter.clear();
+  }
 };


### PR DESCRIPTION
This PR:
- Adds an `emit` alias for `trigger`.
- Adds an `allOff` method which can be used to remove all listeners on an event emitter, or all listeners for a particular event name on an event emitter.

The latter is a convenience to avoid keeping event references around when all you really want to do is clear them all sometimes.
