### PR TITLE
Support for Safari 7.1+ and IE11.

### DIFF
--- a/vertebrate-event-emitter.js
+++ b/vertebrate-event-emitter.js
@@ -63,11 +63,12 @@ EventEmitter.prototype.on = function (eventName, callback, uncheckedCount) {
   var allEventsForThisEventName = allEventsForThisEmitter.get(eventName);
   var eventReference = new EventReference(eventName, callback, count);
 
-  if (allEventsForThisEventName) {
-    allEventsForThisEventName.add(eventReference);
-  } else {
-    allEventsForThisEmitter.set(eventName, new Set([eventReference]));
+  if (!allEventsForThisEventName) {
+    allEventsForThisEventName = new Set();
+    allEventsForThisEmitter.set(eventName, allEventsForThisEventName);
   }
+
+  allEventsForThisEventName.add(eventReference);
 
   return eventReference;
 };


### PR DESCRIPTION
Safari 7.1 / 8 and IE11 have basic support for `Set`, and no support for constructing `Set` instances with arguments. This PR works around that to use only the basic functionality, and in doing so enable support on those platforms.
