### PR TITLE
Now only uses WeakMap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ implementation contained in this repository.
 
 This module uses these ES2015 features:
 
- - [`Set`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Set) ([support](http://kangax.github.io/compat-table/es6/#test-Set))
- - [`Map`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Map) ([support](http://kangax.github.io/compat-table/es6/#test-Map))
- - [`WeakMap`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) ([support](http://kangax.github.io/compat-table/es6/#test-WeakMap))
+ - [`WeakMap`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) ([basic support needed only](http://kangax.github.io/compat-table/es6/#test-WeakMap))
 
 Key features:
 


### PR DESCRIPTION
This is speculative. It will likely make event emissions faster (especially with large sets of callbacks), but removal of reference objects slower. Needs benchmarking before taking any further.

The added benefit is that now this code is completely ES5 with the only addition of basic WeakMap usage.
